### PR TITLE
#3 - remove PHPStan

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,8 +36,5 @@ jobs:
       - name: Run PHP linter
         run: composer ecs
 
-      - name: Run PHP stan
-        run: composer phpstan
-
       - name: Execute tests
         run: php artisan test --env=ci


### PR DESCRIPTION
I believe that errors like this are 100% useless:
![image](https://user-images.githubusercontent.com/10898728/156723622-5965c069-88ae-4bba-af39-957907bfbe36.png)

I'm switching off PHPStan in CI. You can of course use it locally.